### PR TITLE
Pass os.Environ() to template when executing

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -8,10 +8,22 @@
   version = "v1.1.0"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/fatih/camelcase"
+  packages = ["."]
+  revision = "44e46d280b43ec1531bb25252440e34f1b800b65"
+
+[[projects]]
   name = "github.com/joho/godotenv"
   packages = ["."]
   revision = "a79fa1e548e2c689c241d10173efd51e5d689d5b"
   version = "v1.2.0"
+
+[[projects]]
+  branch = "master"
+  name = "github.com/pinzolo/casee"
+  packages = ["."]
+  revision = "956b6baf666aeb716a38e78d8e69823676048099"
 
 [[projects]]
   name = "github.com/pkg/errors"
@@ -40,6 +52,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ca28499cd26c97a1e6ab20b2679853b2123788c996f335396afb1ae3b37f1df"
+  inputs-digest = "bb534ea0fbf0d0f88f8c10a96eb31a87f73227b9a2c9bbc5578888056708161f"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -3,6 +3,10 @@
   version = "1.2.0"
 
 [[constraint]]
+  branch = "master"
+  name = "github.com/pinzolo/casee"
+
+[[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
 

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,26 +1,3 @@
-
-# Gopkg.toml example
-#
-# Refer to https://github.com/golang/dep/blob/master/docs/Gopkg.toml.md
-# for detailed Gopkg.toml documentation.
-#
-# required = ["github.com/user/thing/cmd/thing"]
-# ignored = ["github.com/user/project/pkgX", "bitbucket.org/user/project/pkgA/pkgY"]
-#
-# [[constraint]]
-#   name = "github.com/user/project"
-#   version = "1.0.0"
-#
-# [[constraint]]
-#   name = "github.com/user/project2"
-#   branch = "dev"
-#   source = "github.com/myfork/project2"
-#
-# [[override]]
-#  name = "github.com/x/y"
-#  version = "2.4.0"
-
-
 [[constraint]]
   name = "github.com/joho/godotenv"
   version = "1.2.0"

--- a/cmd/kubeciio-kubectl/main.go
+++ b/cmd/kubeciio-kubectl/main.go
@@ -216,92 +216,12 @@ func generateTemplate(path string) (string, error) {
 		return "", errors.Wrap(err, "failed to parse template")
 	}
 
-	data := struct {
-		DroneArch               string
-		DroneBranch             string
-		DroneBuildCreated       string
-		DroneBuildEvent         string
-		DroneBuildFinished      string
-		DroneBuildLink          string
-		DroneBuildNumber        string
-		DroneBuildStarted       string
-		DroneBuildStatus        string
-		DroneCommit             string
-		DroneCommitAuthor       string
-		DroneCommitAuthorAvatar string
-		DroneCommitAuthorEmail  string
-		DroneCommitBranch       string
-		DroneCommitLink         string
-		DroneCommitMessage      string
-		DroneCommitRef          string
-		DroneCommitSha          string
-		DroneJobFinished        string
-		DroneJobNumber          string
-		DroneJobStarted         string
-		DroneJobStatus          string
-		DroneMachine            string
-		DroneNetrcMachine       string
-		DroneNetrcPassword      string
-		DroneNetrcUsername      string
-		DroneParentBuildNumber  string
-		DronePrevBuildNumber    string
-		DronePrevBuildStatus    string
-		DronePrevCommitSha      string
-		DroneRemoteURL          string
-		DroneRepo               string
-		DroneRepoLink           string
-		DroneRepoName           string
-		DroneRepoOwner          string
-		DroneRepoPrivate        string
-		DroneRepoScm            string
-		DroneWorkspace          string
-	}{
-		DroneArch:               os.Getenv("DRONE_ARCH"),
-		DroneBranch:             os.Getenv("DRONE_BRANCH"),
-		DroneBuildCreated:       os.Getenv("DRONE_BUILD_CREATED"),
-		DroneBuildEvent:         os.Getenv("DRONE_BUILD_EVENT"),
-		DroneBuildFinished:      os.Getenv("DRONE_BUILD_FINISHED"),
-		DroneBuildLink:          os.Getenv("DRONE_BUILD_LINK"),
-		DroneBuildNumber:        os.Getenv("DRONE_BUILD_NUMBER"),
-		DroneBuildStarted:       os.Getenv("DRONE_BUILD_STARTED"),
-		DroneBuildStatus:        os.Getenv("DRONE_BUILD_STATUS"),
-		DroneCommit:             os.Getenv("DRONE_COMMIT"),
-		DroneCommitAuthor:       os.Getenv("DRONE_COMMIT_AUTHOR"),
-		DroneCommitAuthorAvatar: os.Getenv("DRONE_COMMIT_AUTHOR_AVATAR"),
-		DroneCommitAuthorEmail:  os.Getenv("DRONE_COMMIT_AUTHOR_EMAIL"),
-		DroneCommitBranch:       os.Getenv("DRONE_COMMIT_BRANCH"),
-		DroneCommitLink:         os.Getenv("DRONE_COMMIT_LINK"),
-		DroneCommitMessage:      os.Getenv("DRONE_COMMIT_MESSAGE"),
-		DroneCommitRef:          os.Getenv("DRONE_COMMIT_REF"),
-		DroneCommitSha:          os.Getenv("DRONE_COMMIT_SHA"),
-		DroneJobFinished:        os.Getenv("DRONE_JOB_FINISHED"),
-		DroneJobNumber:          os.Getenv("DRONE_JOB_NUMBER"),
-		DroneJobStarted:         os.Getenv("DRONE_JOB_STARTED"),
-		DroneJobStatus:          os.Getenv("DRONE_JOB_STATUS"),
-		DroneMachine:            os.Getenv("DRONE_MACHINE"),
-		DroneNetrcMachine:       os.Getenv("DRONE_NETRC_MACHINE"),
-		DroneNetrcPassword:      os.Getenv("DRONE_NETRC_PASSWORD"),
-		DroneNetrcUsername:      os.Getenv("DRONE_NETRC_USERNAME"),
-		DroneParentBuildNumber:  os.Getenv("DRONE_PARENT_BUILD_NUMBER"),
-		DronePrevBuildNumber:    os.Getenv("DRONE_PREV_BUILD_NUMBER"),
-		DronePrevBuildStatus:    os.Getenv("DRONE_PREV_BUILD_STATUS"),
-		DronePrevCommitSha:      os.Getenv("DRONE_PREV_COMMIT_SHA"),
-		DroneRemoteURL:          os.Getenv("DRONE_REMOTE_URL"),
-		DroneRepo:               os.Getenv("DRONE_REPO"),
-		DroneRepoLink:           os.Getenv("DRONE_REPO_LINK"),
-		DroneRepoName:           os.Getenv("DRONE_REPO_NAME"),
-		DroneRepoOwner:          os.Getenv("DRONE_REPO_OWNER"),
-		DroneRepoPrivate:        os.Getenv("DRONE_REPO_PRIVATE"),
-		DroneRepoScm:            os.Getenv("DRONE_REPO_SCM"),
-		DroneWorkspace:          os.Getenv("DRONE_WORKSPACE"),
-	}
-
 	tmpfile, err := ioutil.TempFile("", filepath.Base(path))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to create tmp file for template")
 	}
 
-	if err := tmpl.Execute(tmpfile, data); err != nil {
+	if err := tmpl.Execute(tmpfile, os.Environ()); err != nil {
 		return "", errors.Wrap(err, "failed to generate file from template")
 	}
 

--- a/cmd/kubeciio-kubectl/main.go
+++ b/cmd/kubeciio-kubectl/main.go
@@ -13,6 +13,7 @@ import (
 	"text/template"
 
 	"github.com/joho/godotenv"
+	"github.com/pinzolo/casee"
 	"github.com/pkg/errors"
 	"github.com/urfave/cli"
 )
@@ -230,4 +231,15 @@ func generateTemplate(path string) (string, error) {
 	}
 
 	return tmpfile.Name(), nil
+}
+
+func environmentVariables() map[string]string {
+	variables := make(map[string]string, len(os.Environ()))
+
+	for _, env := range os.Environ() {
+		pair := strings.SplitN(env, "=", 2)
+		variables[casee.ToPascalCase(pair[0])] = pair[1]
+	}
+
+	return variables
 }


### PR DESCRIPTION
@tboerger left some feedback. 
With the current version we only support some restricted env vars that are drone specific. This also restricts secrets to be used.

Now we simply pass the environment to the template as data and one can also use secrets in the template.