### PR TITLE
Allow templating in kubectl command

### DIFF
--- a/cmd/kubeciio-kubectl/main_test.go
+++ b/cmd/kubeciio-kubectl/main_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,4 +38,16 @@ func TestKubectlNamespace(t *testing.T) {
 	assert.Equal(t, []string{"get", "pods", "-n", "drone"}, args)
 	args = kubectlArgs("get pods --namespace drone", kubectlNamespace("kubeci"))
 	assert.Equal(t, []string{"get", "pods", "--namespace", "drone"}, args)
+}
+
+func TestKubectlCommandTemplating(t *testing.T) {
+	kubectl, err := kubectlCommand("get nodes")
+	assert.NoError(t, err)
+	assert.Equal(t, "get nodes", kubectl)
+
+	os.Setenv("DRONE_COMMIT", "v1.2.3")
+
+	kubectl, err = kubectlCommand("set image deployment/foo container=bar/baz:{{ .DroneCommit }}")
+	assert.NoError(t, err)
+	assert.Equal(t, "set image deployment/foo container=bar/baz:v1.2.3", kubectl)
 }


### PR DESCRIPTION
We want to enable templating in the command as well.
This allows users to for example set the image with `kubectl set image` and use a changing tag